### PR TITLE
unbox collections and Box outside

### DIFF
--- a/src/parameter.rs
+++ b/src/parameter.rs
@@ -27,7 +27,7 @@ pub struct Parameter {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub items: Option<ReferenceOr<Box<Schema>>>,
+    pub items: Option<ReferenceOr<Schema>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/reference.rs
+++ b/src/reference.rs
@@ -12,24 +12,6 @@ pub enum ReferenceOr<T> {
     Item(T),
 }
 
-impl<T> ReferenceOr<T> {
-    pub fn ref_(r: &str) -> Self {
-        ReferenceOr::Reference { reference: r.to_owned() }
-    }
-    pub fn boxed_item(item: T) -> ReferenceOr<Box<T>> {
-        ReferenceOr::Item(Box::new(item))
-    }
-}
-
-impl<T> ReferenceOr<Box<T>> {
-    pub fn unbox(self) -> ReferenceOr<T> {
-        match self {
-            ReferenceOr::Reference { reference } => ReferenceOr::Reference { reference },
-            ReferenceOr::Item(boxed) => ReferenceOr::Item(*boxed),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use crate::{Parameter, ReferenceOr};

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -59,12 +59,12 @@ pub struct Schema {
     pub required: Vec<String>,
     // implies object
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
-    pub properties: IndexMap<String, ReferenceOr<Box<Schema>>>,
+    pub properties: IndexMap<String, ReferenceOr<Schema>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_properties: Option<ReferenceOr<Box<Schema>>>,
+    pub additional_properties: Box<Option<ReferenceOr<Schema>>>,
     // composition
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub all_of: Vec<ReferenceOr<Box<Schema>>>,
+    pub all_of: Vec<ReferenceOr<Schema>>,
     #[serde(default, skip_serializing_if = "is_false")]
     pub read_only: bool,
 
@@ -75,7 +75,7 @@ pub struct Schema {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub items: Option<ReferenceOr<Box<Schema>>>,
+    pub items: Box<Option<ReferenceOr<Schema>>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
fix #15

I reviewed the use of `Box` and this removes a bunch of duplicate functions downstream in `autorust`. I removed `Box` where I could. I also just moved Box to the outside. The compiler suggested it:

```
error[E0072]: recursive type `schema::Schema` has infinite size
  --> src/schema.rs:55:1
   |
55 | pub struct Schema {
   | ^^^^^^^^^^^^^^^^^ recursive type has infinite size
...
78 |     pub items: Option<ReferenceOr<Schema>>,
   |                --------------------------- recursive without indirection
   |
help: insert some indirection (e.g., a `Box`, `Rc`, or `&`) to make `schema::Schema` representable
   |
78 |     pub items: Box<Option<ReferenceOr<Schema>>>,
```

So rather than Option<ReferenceOr<Box<Schema>>>`, I'm using `Box<Option<ReferenceOr<Schema>>>` now. A simple `as_ref()` makes it match the `Option` just fine. 