### PR TITLE
Add support for x-ms-paths, x-ms-odata, and x-ms-error-response

### DIFF
--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -28,6 +28,9 @@ pub struct OpenAPI {
     /// Relative paths to the individual endpoints. They must be relative to the 'basePath'.
     // #[serde(default, skip_serializing_if = "IndexMap::is_empty")] // do not skip
     pub paths: IndexMap<String, ReferenceOr<PathItem>>,
+    /// Relative paths to the individual endpoints. They must be relative to the 'basePath'.
+    #[serde(default, rename = "x-ms-paths", skip_serializing_if = "IndexMap::is_empty")]
+    pub x_ms_paths: IndexMap<String, ReferenceOr<PathItem>>,
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub definitions: IndexMap<String, ReferenceOr<Schema>>,
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -42,4 +42,8 @@ pub struct Operation {
 
     #[serde(rename = "externalDocs", skip_serializing_if = "Option::is_none")]
     pub external_docs: Option<ExternalDocumentation>,
+
+    /// A reference to the definition that describes object used in the odata filter
+    #[serde(rename = "x-ms-odata", skip_serializing_if = "Option::is_none")]
+    pub x_ms_odata: Option<String>,
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -48,8 +48,8 @@ pub struct Response {
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub headers: IndexMap<String, ReferenceOr<Header>>,
 
-    #[serde(default, rename = "x-ms-error-response", skip_serializing_if = "std::ops::Not::not")]
-    pub x_ms_error_response: bool,
+    #[serde(rename = "x-ms-error-response", skip_serializing_if = "Option::is_none")]
+    pub x_ms_error_response: Option<bool>,
 }
 
 /// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schemaObject

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -47,6 +47,9 @@ pub struct Response {
     pub schema: Option<ReferenceOr<Schema>>,
     #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
     pub headers: IndexMap<String, ReferenceOr<Header>>,
+
+    #[serde(default, rename = "x-ms-error-response", skip_serializing_if = "std::ops::Not::not")]
+    pub x_ms_error_response: bool,
 }
 
 /// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schemaObject
@@ -143,4 +146,7 @@ pub struct Schema {
 
     #[serde(rename = "x-ms-discriminator-value", skip_serializing_if = "Option::is_none")]
     pub x_ms_discriminator_value: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub example: Option<serde_json::Value>,
 }

--- a/tests/azure_rest_api_specs.rs
+++ b/tests/azure_rest_api_specs.rs
@@ -8,6 +8,7 @@ const PATHS: &[&str] = &[
     "../azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2020-04-01/cosmos-db.json",
     "../azure-rest-api-specs/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/ActionRules.json",
     "../azure-rest-api-specs/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/apimapis.json",
+    "../azure-rest-api-specs/specification/communication/data-plane/Microsoft.CommunicationServicesChat/preview/2020-09-21-preview2/communicationserviceschat.json",
 ];
 
 // cargo test --test azure_rest_api_specs

--- a/tests/azure_rest_api_specs.rs
+++ b/tests/azure_rest_api_specs.rs
@@ -1,27 +1,24 @@
 mod common;
 use common::*;
 
+const PATHS: &[&str] = &[
+    "../azure-rest-api-specs/specification/vmware/resource-manager/Microsoft.AVS/stable/2020-03-20/vmware.json",
+    "../azure-rest-api-specs/specification/batch/data-plane/Microsoft.Batch/stable/2020-03-01.11.0/BatchService.json",
+    "../azure-rest-api-specs/specification/security/resource-manager/common/v1/types.json",
+    "../azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2020-04-01/cosmos-db.json",
+    "../azure-rest-api-specs/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/ActionRules.json",
+    "../azure-rest-api-specs/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/apimapis.json",
+];
+
 // cargo test --test azure_rest_api_specs
 // These tests require cloning azure-rest-api-specs.
 // git clone git@github.com:Azure/azure-rest-api-specs.git ../azure-rest-api-specs
 #[test]
 fn can_deserialize_azure_rest_api_specs() -> Result<()> {
-    assert_deserialize_without_ignored(vec![
-        "../azure-rest-api-specs/specification/vmware/resource-manager/Microsoft.AVS/stable/2020-03-20/vmware.json",
-        "../azure-rest-api-specs/specification/batch/data-plane/Microsoft.Batch/stable/2020-03-01.11.0/BatchService.json",
-        "../azure-rest-api-specs/specification/security/resource-manager/common/v1/types.json",
-        "../azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2020-04-01/cosmos-db.json",
-        "../azure-rest-api-specs/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/ActionRules.json"
-    ])
+    assert_deserialize_without_ignored(PATHS)
 }
 
 #[test]
 fn can_roundtrip_azure_rest_api_specs() -> Result<()> {
-    assert_roundtrip_eq(vec![
-        "../azure-rest-api-specs/specification/vmware/resource-manager/Microsoft.AVS/stable/2020-03-20/vmware.json",
-        "../azure-rest-api-specs/specification/batch/data-plane/Microsoft.Batch/stable/2020-03-01.11.0/BatchService.json",
-        "../azure-rest-api-specs/specification/security/resource-manager/common/v1/types.json",
-        "../azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2020-04-01/cosmos-db.json",
-        "../azure-rest-api-specs/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/ActionRules.json"
-    ])
+    assert_roundtrip_eq(PATHS)
 }

--- a/tests/azure_rest_api_specs.rs
+++ b/tests/azure_rest_api_specs.rs
@@ -7,7 +7,8 @@ const PATHS: &[&str] = &[
     "../azure-rest-api-specs/specification/security/resource-manager/common/v1/types.json",
     "../azure-rest-api-specs/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2020-04-01/cosmos-db.json",
     "../azure-rest-api-specs/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/ActionRules.json",
-    "../azure-rest-api-specs/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/apimapis.json",
+    // https://github.com/ctaggart/autorust_openapi/issues/20
+    // "../azure-rest-api-specs/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/apimapis.json",
     "../azure-rest-api-specs/specification/communication/data-plane/Microsoft.CommunicationServicesChat/preview/2020-09-21-preview2/communicationserviceschat.json",
 ];
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,7 +6,7 @@ use std::{fs::File, io::Read, path::Path};
 pub type Error = Box<dyn std::error::Error>;
 pub type Result<T> = std::result::Result<T, Error>;
 
-pub fn assert_deserialize_without_ignored<P: AsRef<Path> + std::fmt::Debug>(paths: Vec<P>) -> Result<()> {
+pub fn assert_deserialize_without_ignored<P: AsRef<Path> + std::fmt::Debug>(paths: &[P]) -> Result<()> {
     for path in paths {
         println!("  test {:?}", path);
         let mut bytes = Vec::new();
@@ -15,15 +15,20 @@ pub fn assert_deserialize_without_ignored<P: AsRef<Path> + std::fmt::Debug>(path
         let mut ignored = Vec::new();
         let _spec: OpenAPI = serde_ignored::deserialize(deserializer, |path| {
             let path = path.to_string();
-            println!("    ignored {}", &path);
+            eprintln!("    ignored {}", &path);
             ignored.push(path);
         })?;
-        assert_eq!(0, ignored.len());
+        assert_eq!(
+            0,
+            ignored.len(),
+            "A total of {} fields were ignored when deserializing",
+            ignored.len()
+        );
     }
     Ok(())
 }
 
-pub fn assert_roundtrip_eq<P: AsRef<Path> + std::fmt::Debug>(paths: Vec<P>) -> Result<()> {
+pub fn assert_roundtrip_eq<P: AsRef<Path> + std::fmt::Debug>(paths: &[P]) -> Result<()> {
     for path in paths {
         println!("  test {:?}", path);
         let mut bytes = Vec::new();

--- a/tests/openapi_spec_examples.rs
+++ b/tests/openapi_spec_examples.rs
@@ -1,27 +1,23 @@
 mod common;
 use common::*;
 
+const PATHS: &[&str] = &[
+    "../OpenAPI-Specification/examples/v2.0/json/petstore-minimal.json",
+    "../OpenAPI-Specification/examples/v2.0/json/petstore.json",
+    "../OpenAPI-Specification/examples/v2.0/json/petstore-simple.json",
+    "../OpenAPI-Specification/examples/v2.0/json/petstore-with-external-docs.json",
+    "../OpenAPI-Specification/examples/v2.0/json/uber.json",
+];
+
 // cargo test --test openapi_spec_examples
 // These tests require cloning OpenAPI-Specification.
 // git clone git@github.com:OAI/OpenAPI-Specification.git ../OpenAPI-Specification
 #[test]
 fn can_deserialize_openapi_spec_examples() -> Result<()> {
-    assert_deserialize_without_ignored(vec![
-        "../OpenAPI-Specification/examples/v2.0/json/petstore-minimal.json",
-        "../OpenAPI-Specification/examples/v2.0/json/petstore.json",
-        "../OpenAPI-Specification/examples/v2.0/json/petstore-simple.json",
-        "../OpenAPI-Specification/examples/v2.0/json/petstore-with-external-docs.json",
-        "../OpenAPI-Specification/examples/v2.0/json/uber.json",
-    ])
+    assert_deserialize_without_ignored(PATHS)
 }
 
 #[test]
 fn can_roundtrip_openapi_spec_examples() -> Result<()> {
-    assert_roundtrip_eq(vec![
-        "../OpenAPI-Specification/examples/v2.0/json/petstore-minimal.json",
-        "../OpenAPI-Specification/examples/v2.0/json/petstore.json",
-        "../OpenAPI-Specification/examples/v2.0/json/petstore-simple.json",
-        "../OpenAPI-Specification/examples/v2.0/json/petstore-with-external-docs.json",
-        "../OpenAPI-Specification/examples/v2.0/json/uber.json",
-    ])
+    assert_roundtrip_eq(PATHS)
 }


### PR DESCRIPTION
There are two issues with this PR:
* The tests fail because the newest json we're testing against (apimapis.json) [includes empty "definitions" and "parameters" keys](https://github.com/Azure/azure-rest-api-specs/blob/654e235d1f32ce68d7f907a8621d8519b56b08b7/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/apimapis.json#L4468-L4469) while the other json files do not include these when they are empty. In other words, sometimes they are included when empty, and sometimes they are not. We should think about patching `assert_json_diff` to allow for empty objects to be treated as though the key is not present. 
* The `x_ms_odata` key is modeled as an `Option<String>`. The `String` in this case is always a reference to another file with the object's definition. Unfortunately, normally references are json objects with one key "$ref", but in this case it's just the string value without the key. We should think about how to unify these difference types of references. 

This should close #3 though there is still one extension "x-ms-text" which doesn't seem to be in any of the Azure REST spec json files. 