### PR TITLE
put common fields in SchemaCommon

### DIFF
--- a/src/parameter.rs
+++ b/src/parameter.rs
@@ -1,63 +1,29 @@
-use crate::{DataType, MsEnum, MsParameterGrouping, ReferenceOr, Schema};
+use crate::{MsParameterGrouping, ReferenceOr, Schema, SchemaCommon};
 use serde::{Deserialize, Serialize};
 
 /// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameter-object
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Parameter {
+    #[serde(flatten)]
+    pub common: SchemaCommon,
+
     /// The name of the parameter.
     pub name: String,
-    /// values depend on parameter type
+
     /// may be `header`, `query`, 'path`, `formData`
     #[serde(rename = "in")]
     pub in_: String,
-    /// A brief description of the parameter. This could contain examples
-    /// of use.  GitHub Flavored Markdown is allowed.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub required: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<ReferenceOr<Schema>>,
 
-    // fields also in Schema Object
-    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
-    pub type_: Option<DataType>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub format: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub items: Option<ReferenceOr<Schema>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub default: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub maximum: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub exclusive_maximum: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub minimum: Option<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub exclusive_minimum: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_length: Option<usize>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub min_length: Option<usize>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub pattern: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_items: Option<usize>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub min_items: Option<usize>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub unique_items: Option<bool>,
-    #[serde(rename = "enum", default, skip_serializing_if = "Vec::is_empty")]
-    pub enum_: Vec<serde_json::Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub multiple_of: Option<f64>,
-
-    // fields not in Schema Object
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_empty_value: Option<bool>,
+    
     #[serde(skip_serializing_if = "Option::is_none")]
     pub collection_format: Option<String>,
 
@@ -76,14 +42,6 @@ pub struct Parameter {
     #[serde(rename = "x-ms-parameter-grouping", skip_serializing_if = "Option::is_none")]
     pub x_ms_parameter_grouping: Option<MsParameterGrouping>,
 
-    /// additional metadata for enums
-    /// https://github.com/Azure/autorest/blob/master/docs/extensions/readme.md#x-ms-enum
-    #[serde(rename = "x-ms-enum", skip_serializing_if = "Option::is_none")]
-    pub x_ms_enum: Option<MsEnum>,
-
     #[serde(rename = "x-ms-client-request-id", skip_serializing_if = "Option::is_none")]
     pub x_ms_client_request_id: Option<bool>,
-
-    #[serde(rename = "x-ms-client-name", skip_serializing_if = "Option::is_none")]
-    pub x_ms_client_name: Option<String>,
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -59,61 +59,61 @@ pub enum AdditionalProperties {
     Schema(ReferenceOr<Schema>),
 }
 
+/// common fields in both Schema Object & Parameter Object
 /// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schemaObject
+/// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameter-object
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub struct Schema {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
+pub struct SchemaCommon {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub required: Vec<String>,
-    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
-    pub properties: IndexMap<String, ReferenceOr<Schema>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_properties: Box<Option<AdditionalProperties>>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub all_of: Vec<ReferenceOr<Schema>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub discriminator: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub read_only: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub external_docs: Option<ExternalDocumentation>,
 
-    // fields also found in Parameter Object
-    // https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameter-object
+    /// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#items-object
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub type_: Option<DataType>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub items: Box<Option<ReferenceOr<Schema>>>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default: Option<serde_json::Value>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub maximum: Option<serde_json::Value>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exclusive_maximum: Option<bool>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub minimum: Option<serde_json::Value>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exclusive_minimum: Option<bool>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_length: Option<usize>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub min_length: Option<usize>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pattern: Option<String>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_items: Option<usize>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub min_items: Option<usize>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unique_items: Option<bool>,
+
     #[serde(rename = "enum", default, skip_serializing_if = "Vec::is_empty")]
     pub enum_: Vec<serde_json::Value>,
+    
     #[serde(skip_serializing_if = "Option::is_none")]
     pub multiple_of: Option<f64>,
 
@@ -121,6 +121,41 @@ pub struct Schema {
     /// https://github.com/Azure/autorest/blob/master/docs/extensions/readme.md#x-ms-enum
     #[serde(rename = "x-ms-enum", skip_serializing_if = "Option::is_none")]
     pub x_ms_enum: Option<MsEnum>,
+
+    #[serde(rename = "x-ms-client-name", skip_serializing_if = "Option::is_none")]
+    pub x_ms_client_name: Option<String>,
+}
+
+/// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#schemaObject
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Schema {
+    #[serde(flatten)]
+    pub common: SchemaCommon,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "IndexMap::is_empty")]
+    pub properties: IndexMap<String, ReferenceOr<Schema>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additional_properties: Box<Option<AdditionalProperties>>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub all_of: Vec<ReferenceOr<Schema>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discriminator: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub read_only: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_docs: Option<ExternalDocumentation>,
 
     #[serde(rename = "x-ms-secret", skip_serializing_if = "Option::is_none")]
     pub x_ms_secret: Option<bool>,
@@ -139,14 +174,6 @@ pub struct Schema {
     /// https://github.com/Azure/autorest/blob/master/docs/extensions/readme.md#x-ms-external
     #[serde(rename = "x-ms-external", skip_serializing_if = "Option::is_none")]
     pub x_ms_external: Option<bool>,
-
-    /// groups method parameters in generated clients
-    /// https://github.com/Azure/autorest/blob/master/docs/extensions/readme.md#x-ms-parameter-grouping
-    #[serde(rename = "x-ms-parameter-grouping", skip_serializing_if = "Option::is_none")]
-    pub x_ms_parameter_grouping: Option<MsParameterGrouping>,
-
-    #[serde(rename = "x-ms-client-name", skip_serializing_if = "Option::is_none")]
-    pub x_ms_client_name: Option<String>,
 
     #[serde(rename = "x-nullable", skip_serializing_if = "Option::is_none")]
     pub x_nullable: Option<bool>,


### PR DESCRIPTION
This groups commons fields in both Schema Object & Parameter Object into a `SchemaCommon` type. The type is flattened for serialization. 