### PR TITLE
Add File as a variant of DataType

### DIFF
--- a/src/schema.rs
+++ b/src/schema.rs
@@ -32,6 +32,7 @@ pub enum DataType {
     Boolean,
     Array,
     Object,
+    File,
 }
 
 /// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#securityRequirementObject


### PR DESCRIPTION
Schemas can have the type "file" which is not currently supported by the autorust_openapi parser. In particular [this file](https://github.com/Azure/azure-rest-api-specs/blob/a3c19b3dc7d14848daecaf9b9bf42249c7f91a9d/specification/automation/resource-manager/Microsoft.Automation/stable/2015-10-31/job.json#L78-L80) fails to parse because of this, and this the `automation` service cannot be generated.

The OpenAPI docs say the following: 
> An additional primitive data type "file" is used by the Parameter Object and the Response Object to set the parameter type or the response as being a file..

This change is trivial for autorust_openapi but brings the need for some non-trivial refactoring in autorust itself as this is first response type that is not JSON. 