### PR TITLE
add operation_ids example

### DIFF
--- a/examples/operation_ids.rs
+++ b/examples/operation_ids.rs
@@ -1,0 +1,43 @@
+// Print the operation IDs alphabetically
+// cargo run --example operation_ids -- ../azure-rest-api-specs/specification/vmware/resource-manager/Microsoft.AVS/stable/2020-03-20/vmware.json
+
+use autorust_openapi::*;
+use std::{
+    fs::{self},
+    path::Path,
+    process::exit,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    match std::env::args().nth(1) {
+        None => {
+            eprintln!("Please pass in the spec path.");
+            exit(1);
+        }
+        Some(file_in) => {
+            let file_in = Path::new(&file_in);
+            let bytes = fs::read(file_in)?;
+            let api: OpenAPI = serde_json::from_slice(&bytes)?;
+
+            let mut operation_ids = Vec::new();
+            for (_path, item) in &api.paths {
+                match item {
+                    ReferenceOr::Reference { .. } => (),
+                    ReferenceOr::Item(item) => {
+                        for op in item.operations() {
+                            if let Some(operation_id) = &op.operation_id {
+                                operation_ids.push(operation_id);
+                            }
+                        }
+                    }
+                }
+            }
+
+            operation_ids.sort();
+            for operation_id in operation_ids {
+                println!("{}", operation_id);
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -21,3 +21,20 @@ pub struct PathItem {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub parameters: Vec<ReferenceOr<Parameter>>,
 }
+
+impl PathItem {
+    /// Returns all operations
+    pub fn operations(&self) -> impl Iterator<Item = &Operation> {
+        vec![
+            self.get.as_ref(),
+            self.post.as_ref(),
+            self.put.as_ref(),
+            self.patch.as_ref(),
+            self.delete.as_ref(),
+            self.options.as_ref(),
+            self.head.as_ref(),
+        ]
+        .into_iter()
+        .filter_map(|x| x)
+    }
+}

--- a/tests/azure_rest_api_specs.rs
+++ b/tests/azure_rest_api_specs.rs
@@ -13,7 +13,7 @@ const PATHS: &[&str] = &[
     "../azure-rest-api-specs/specification/alertsmanagement/resource-manager/Microsoft.AlertsManagement/preview/2019-05-05-preview/ActionRules.json",
     // https://github.com/ctaggart/autorust_openapi/issues/20
     // "../azure-rest-api-specs/specification/apimanagement/resource-manager/Microsoft.ApiManagement/stable/2019-12-01/apimapis.json",
-    "../azure-rest-api-specs/specification/communication/data-plane/Microsoft.CommunicationServicesChat/preview/2020-09-21-preview2/communicationserviceschat.json",
+    "../azure-rest-api-specs/specification/communication/data-plane/Chat/stable/2021-03-07/communicationserviceschat.json",
     "../azure-rest-api-specs/specification/eventgrid/data-plane/Microsoft.EventGrid/stable/2018-01-01/EventGrid.json",
 ];
 


### PR DESCRIPTION
Also adds `operations` to `PathItem`. From https://github.com/Azure/azure-sdk-for-rust/blob/29d904b711827b64fb3c32c36ed24a68da334cc9/services/autorust/codegen/src/spec.rs#L404-L416